### PR TITLE
Catch panics in datadog error handling

### DIFF
--- a/src/datadog.rs
+++ b/src/datadog.rs
@@ -69,11 +69,11 @@ impl DatadogBuilder {
     ///
     /// For example, this could be something like `"hostname"`, or similar.
     pub fn global_tag(mut self, key: &str, value: &str) -> Self {
-        if !self.global_tags.is_empty() {
-            self.global_tags.push(',');
-        }
         let formatted_tag = format!("{key}:{value}");
         if let Ok(formatted_tag) = serde_json::to_string(&formatted_tag) {
+            if !self.global_tags.is_empty() {
+                self.global_tags.push(',');
+            }
             self.global_tags.push_str(&formatted_tag);
         }
         self


### PR DESCRIPTION
The datadog sink panics if it is not able to send a request to Datadog, for
example due to connection issues. Likewise, it panics when there's a problem
reading an error reponse.

This PR removes all uses of `unwrap()` from the Datadog implementation.
Specifically:

 1. We catch all errors that happen on sending requests and retrieving the error
    response.
 2. Other uses of `unwrap()` fall into the _should-not-happen_ category, but we
    can also avoid them with `if let`.

